### PR TITLE
Fix empty edit image

### DIFF
--- a/modules/ace_plus_dataset.py
+++ b/modules/ace_plus_dataset.py
@@ -152,7 +152,7 @@ class ACEPlusDataset(BaseDataset):
         edit_id, ref_id, src_image_list, src_mask_list = [], [], [], []
         # parse editing image
         if edit_image is None:
-            edit_image = Image.new("RGB", target_image.size, 255)
+            edit_image = Image.new("RGB", target_image.size, (255, 255, 255))
             edit_mask = Image.new("L", edit_image.size, 255)
         elif edit_mask is None:
             edit_mask = Image.new("L", edit_image.size, 255)


### PR DESCRIPTION
The current implementation incorrectly assigns a "red" image when an empty edit image is created.

This happens because Image.new("RGB", target_image.size, 255) interprets 255 as (255, 0, 0). If this is not the intended behavior, it should be explicitly set to "white" using (255, 255, 255).

This change ensures that when the edit image is not used in the dataset, it defaults to a white image instead of a red one.

Let me know if I misunderstood anything!


---

Here is my test code

<img width="625" alt="image" src="https://github.com/user-attachments/assets/18b9fff7-ea51-4e4d-a63a-0ec0985b6c9b" />
