### PR TITLE
Fix inference with fft

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,9 @@ python infer_lora.py
 The relevant commands for fft models are as follows:
 ```bash
 export FLUX_FILL_PATH="hf://black-forest-labs/FLUX.1-Fill-dev"
-export ACE_PLUS_FFT_MODEL="ms://iic/ACE_Plus@ace_plus_fft.safetensors.safetensors"                                                                                                                                      
+export ACE_PLUS_FFT_MODEL="ms://iic/ACE_Plus@ace_plus_fft.safetensors.safetensors"
+# Use the model from huggingface
+# export "ACE_PLUS_FFT_MODEL=hf://ali-vilab/ACE_Plus@ace_plus_fft.safetensors"
 python infer_fft.py
 ```
 

--- a/config/ace_plus_fft.yaml
+++ b/config/ace_plus_fft.yaml
@@ -72,7 +72,7 @@ MODEL:
   FIRST_STAGE_MODEL:
     NAME: AutoencoderKLFlux
     EMBED_DIM: 16
-    PRETRAINED_MODEL: ${FLUX_FILL_PATH}/ae.safetensors
+    PRETRAINED_MODEL: ${FLUX_FILL_PATH}@ae.safetensors
     IGNORE_KEYS: [ ]
     BATCH_SIZE: 8
     USE_CONV: False
@@ -116,11 +116,11 @@ MODEL:
       # HF_MODEL_CLS DESCRIPTION: huggingface cls in transfomer TYPE: NoneType default: None
       HF_MODEL_CLS: T5EncoderModel
       # MODEL_PATH DESCRIPTION: model folder path TYPE: NoneType default: None
-      MODEL_PATH: ${FLUX_FILL_PATH}/text_encoder_2/
+      MODEL_PATH: ${FLUX_FILL_PATH}@text_encoder_2/
       # HF_TOKENIZER_CLS DESCRIPTION: huggingface cls in transfomer TYPE: NoneType default: None
       HF_TOKENIZER_CLS: T5Tokenizer
       # TOKENIZER_PATH DESCRIPTION: tokenizer folder path TYPE: NoneType default: None
-      TOKENIZER_PATH: ${FLUX_FILL_PATH}/tokenizer_2/
+      TOKENIZER_PATH: ${FLUX_FILL_PATH}@tokenizer_2/
       ADDED_IDENTIFIER: [ '<img>','{image}', '{caption}', '{mask}', '{ref_image}', '{image1}', '{image2}', '{image3}', '{image4}', '{image5}', '{image6}', '{image7}', '{image8}', '{image9}' ]
       # MAX_LENGTH DESCRIPTION: max length of input TYPE: int default: 77
       MAX_LENGTH: 512
@@ -138,11 +138,11 @@ MODEL:
       # HF_MODEL_CLS DESCRIPTION: huggingface cls in transfomer TYPE: NoneType default: None
       HF_MODEL_CLS: CLIPTextModel
       # MODEL_PATH DESCRIPTION: model folder path TYPE: NoneType default: None
-      MODEL_PATH: ${FLUX_FILL_PATH}/text_encoder/
+      MODEL_PATH: ${FLUX_FILL_PATH}@text_encoder/
       # HF_TOKENIZER_CLS DESCRIPTION: huggingface cls in transfomer TYPE: NoneType default: None
       HF_TOKENIZER_CLS: CLIPTokenizer
       # TOKENIZER_PATH DESCRIPTION: tokenizer folder path TYPE: NoneType default: None
-      TOKENIZER_PATH: ${FLUX_FILL_PATH}/tokenizer/
+      TOKENIZER_PATH: ${FLUX_FILL_PATH}@tokenizer/
       # MAX_LENGTH DESCRIPTION: max length of input TYPE: int default: 77
       MAX_LENGTH: 77
       # OUTPUT_KEY DESCRIPTION: output key TYPE: str default: 'last_hidden_state'


### PR DESCRIPTION
Currently running infer_fft.py fails with the following error

```bash
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/scepter/modules/utils/registry.py", line 85, in build_from_config
    return req_type_entry(cfg, logger=logger, *args, **kwargs)
  File "/workspace/dtback/ACE_plus/modules/ace_plus_ldm.py", line 21, in __init__
    super().__init__(cfg, logger=logger)
  File "/usr/local/lib/python3.10/dist-packages/scepter/modules/model/network/ldm/ldm.py", line 91, in __init__
    self.construct_network()
  File "/workspace/dtback/ACE_plus/modules/ace_plus_ldm.py", line 78, in construct_network
    self.first_stage_model = MODELS.build(self.first_stage_config,
  File "/usr/local/lib/python3.10/dist-packages/scepter/modules/utils/registry.py", line 142, in build
    return self.build_func(cfg,
  File "/usr/local/lib/python3.10/dist-packages/scepter/modules/model/registry.py", line 26, in build_model
    model.load_pretrained_model(pretrain_cfg)
  File "/usr/local/lib/python3.10/dist-packages/scepter/modules/model/network/autoencoder/ae_kl.py", line 366, in load_pretrained_model
    with FS.get_from(pretrained_model, wait_finish=True) as local_model:
  File "/usr/local/lib/python3.10/dist-packages/scepter/modules/utils/file_system.py", line 245, in get_from
    local_path = client.get_object_to_local_file(
  File "/usr/local/lib/python3.10/dist-packages/scepter/modules/utils/file_clients/huggingface_fs.py", line 49, in get_object_to_local_file
    key, file_path = key.split('@', 1)
ValueError: not enough values to unpack (expected 2, got 1)
```

this pr fixes the problem